### PR TITLE
Add v0.17.4, v0.17.5 and set default to v0.17.5

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for atlantis
 atlantis_mirror: https://github.com/runatlantis/atlantis/releases/download
-atlantis_ver: v0.17.3
+atlantis_ver: v0.17.5
 
 atlantis_os: linux
 atlantis_arch: amd64

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -144,3 +144,12 @@ atlantis_checksums:
     linux_arm: sha256:c0d5450ab8c71fed2287c57e67219fc9adee736647eb87e84712e38e2ae4a30c
     # https://github.com/runatlantis/atlantis/releases/download/v0.17.3/atlantis_darwin_amd64.zip
     darwin_amd64: sha256:a22830a6fdfd7bb835be552e9d2909be873ab6f9deb49554606f2bd641c97dd9
+  v0.17.4:
+    # https://github.com/runatlantis/atlantis/releases/download/v0.17.4/atlantis_linux_amd64.zip
+    linux_amd64: sha256:f08dc5cc6d380c70d4ba5e89cdfe33784398ae97949887db22a1175cec74f277
+    # https://github.com/runatlantis/atlantis/releases/download/v0.17.4/atlantis_linux_386.zip
+    linux_386: sha256:04c20afc50a40d740d15113d197ccd9cb3fde0fb8351f13f0d55d0c9dbca15d7
+    # https://github.com/runatlantis/atlantis/releases/download/v0.17.4/atlantis_linux_arm.zip
+    linux_arm: sha256:4238cacd391789d4bd730eea2345b5005e85721cd1791b13e736dc6291fdcf75
+    # https://github.com/runatlantis/atlantis/releases/download/v0.17.4/atlantis_darwin_amd64.zip
+    darwin_amd64: sha256:2da660da7ddd176d63628e1295aad01712368b576c4ecf562d7dc8bd4aebf0a6

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -153,3 +153,12 @@ atlantis_checksums:
     linux_arm: sha256:4238cacd391789d4bd730eea2345b5005e85721cd1791b13e736dc6291fdcf75
     # https://github.com/runatlantis/atlantis/releases/download/v0.17.4/atlantis_darwin_amd64.zip
     darwin_amd64: sha256:2da660da7ddd176d63628e1295aad01712368b576c4ecf562d7dc8bd4aebf0a6
+  v0.17.5:
+    # https://github.com/runatlantis/atlantis/releases/download/v0.17.5/atlantis_linux_amd64.zip
+    linux_amd64: sha256:430d08456648e79aca805d601dcb1c31a8985858e321a99fd8399a7119d3368a
+    # https://github.com/runatlantis/atlantis/releases/download/v0.17.5/atlantis_linux_386.zip
+    linux_386: sha256:13006fa16a35ef2f62fd603c73e9b6370ba48ff3ad277e240cecb60ff427daaa
+    # https://github.com/runatlantis/atlantis/releases/download/v0.17.5/atlantis_linux_arm.zip
+    linux_arm: sha256:394542873423b0be74f99659b2e4a4e2327c53a4b565b0c864817c501e83062c
+    # https://github.com/runatlantis/atlantis/releases/download/v0.17.5/atlantis_darwin_amd64.zip
+    darwin_amd64: sha256:f75945bd59e0cf2b1c40423c44b7f528ebd256643547daa03bf8d0b3783a4cff

--- a/dl-checksum.sh
+++ b/dl-checksum.sh
@@ -27,4 +27,4 @@ dl_ver() {
     dl $ver darwin amd64
 }
 
-dl_ver ${1:-v0.17.3}
+dl_ver ${1:-v0.17.5}


### PR DESCRIPTION
Hi Andrew, 

this MR 
- adds atlantis version v0.17.4 and v0.17.5.
- sets the default version to v0.17.5

Bests
Flo